### PR TITLE
Remove Choroba's first name.

### DIFF
--- a/Czech.pm
+++ b/Czech.pm
@@ -10,7 +10,7 @@ our $VERSION = 0.22;
 
 # Modules.
 use Acme::CPANAuthors::Register(
-	'CHOROBA' => 'Egon Choroba',
+	'CHOROBA' => 'E. Choroba',
 	'DANIELR' => 'Roman Daniel',
 	'DANPEDER' => 'Daniel Peder',
 	'DOUGLISH' => 'Dalibor Hořínek',

--- a/t/Acme-CPANAuthors-Czech/04-authors.t
+++ b/t/Acme-CPANAuthors-Czech/04-authors.t
@@ -11,7 +11,7 @@ use Test::NoWarnings;
 # Test.
 my %ret = Acme::CPANAuthors::Czech->authors;
 my %right_ret = (
-	'CHOROBA' => 'Egon Choroba',
+	'CHOROBA' => 'E. Choroba',
 	'DANIELR' => 'Roman Daniel',
 	'DANPEDER' => 'Daniel Peder',
 	'DOUGLISH' => 'Dalibor Hořínek',


### PR DESCRIPTION
It's used only on Facebook where "E." was rejected as "containing too
many punctuation characters" and "E" was rejected as "too short".
